### PR TITLE
Fix dns

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,11 +47,9 @@ resource "aws_security_group" "default" {
 }
 
 module "dns" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.1.1"
-  namespace = "${var.namespace}"
-  name      = "${var.name}"
-  stage     = "${var.stage}"
-  ttl       = 60
-  zone_id   = "${var.zone_id}"
-  records   = ["${aws_efs_file_system.default.id}.efs.${var.aws_region}.amazonaws.com"]
+  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.1.1"
+  name    = "${module.label.id}"
+  ttl     = 60
+  zone_id = "${var.zone_id}"
+  records = ["${aws_efs_file_system.default.id}.efs.${var.aws_region}.amazonaws.com"]
 }

--- a/main.tf
+++ b/main.tf
@@ -10,11 +10,7 @@ module "label" {
 }
 
 resource "aws_efs_file_system" "default" {
-  tags {
-    Name      = "${module.label.id}"
-    Namespace = "${var.namespace}"
-    Stage     = "${var.stage}"
-  }
+  tags = "${module.label.tags}"
 }
 
 resource "aws_efs_mount_target" "default" {

--- a/main.tf
+++ b/main.tf
@@ -47,11 +47,7 @@ resource "aws_security_group" "default" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
-    Name      = "${module.label.id}"
-    Namespace = "${var.namespace}"
-    Stage     = "${var.stage}"
-  }
+  tags = "${module.label.tags}"
 }
 
 module "dns" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,3 +5,7 @@ output "id" {
 output "host" {
   value = "${module.dns.hostname}"
 }
+
+output "dns_name" {
+  value = "${aws_efs_file_system.default.id}.efs.${var.aws_region}.amazonaws.com"
+}


### PR DESCRIPTION
## What

* Fixed `tags` attribute for the internal resources
* Added `dns_name` output
* Changed `name` attribute of the internal `dns` module


## Why

*  Use `tags` output from the `terrafor-null-label` module to follow our naming convention

* `dns_name` is the internal `DNS` record assigned to the `EFS`. When mounting `EC2` directory to the `EFS` filesystem, we don't need to use the public `DNS` record.
The auto-generated private `DNS` record is faster and more secure

* The `name` attribute was too generic and conflicted with other modules which created DNS records with the same names, e.g. `jenkins.cloudposse.com`.
Use the `id` from the `terrafor-null-label` module to follow our naming convention and to create unique `DNS` records
