### PR TITLE
Add mount_target_ips output

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ module "efs" {
 | id               | EFS id                                                           |
 | host             | Assigned DNS-record for the EFS                                  |
 | mount_target_ids | List of IDs of the EFS mount targets (one per Availability Zone) |
+| mount_target_ips | List of IPs of the EFS mount targets (one per Availability Zone) |

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,3 +13,7 @@ output "dns_name" {
 output "mount_target_ids" {
   value = ["${aws_efs_mount_target.default.*.id}"]
 }
+
+output "mount_target_ips" {
+  value = ["${aws_efs_mount_target.default.*.ip_address}"]
+}


### PR DESCRIPTION
## What
* Add mount_target_ips output

## Why
* Can't use `dns_name` attribute in a VPC without `DNS hostnames` enabled
* Can't use `dns_name` attribute with a custom DNS servers in `/etc/resolv.conf` or custom DHCP Option Set

## Plan
