### PR TITLE
Add options for performance_mode and encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,10 @@ Available targets:
 | availability_zones | Availability Zone IDs | list | - | yes |
 | aws_region | AWS region ID | string | - | yes |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
+| encrypted | If true, the disk will be encrypted. | string | `false` | no |
 | name | Name (_e.g._ `app` or `wordpress`) | string | `app` | no |
 | namespace | Namespace (_e.g._ `cp` or `cloudposse`) | string | `global` | no |
+| performance_mode | The file system performance mode. Can be either `generalPurpose` or `maxIO` | string | `generalPurpose` | no |
 | security_groups | AWS security group IDs to allow to connect to the EFS | list | - | yes |
 | stage | Stage (_e.g._ `prod`, `dev`, `staging`) | string | `default` | no |
 | subnets | AWS subnet IDs | list | - | yes |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -7,8 +7,10 @@
 | availability_zones | Availability Zone IDs | list | - | yes |
 | aws_region | AWS region ID | string | - | yes |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
+| encrypted | If true, the disk will be encrypted. | string | `false` | no |
 | name | Name (_e.g._ `app` or `wordpress`) | string | `app` | no |
 | namespace | Namespace (_e.g._ `cp` or `cloudposse`) | string | `global` | no |
+| performance_mode | The file system performance mode. Can be either `generalPurpose` or `maxIO` | string | `generalPurpose` | no |
 | security_groups | AWS security group IDs to allow to connect to the EFS | list | - | yes |
 | stage | Stage (_e.g._ `prod`, `dev`, `staging`) | string | `default` | no |
 | subnets | AWS subnet IDs | list | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,8 @@ module "label" {
 
 resource "aws_efs_file_system" "default" {
   tags = "${module.label.tags}"
+  encrypted = "${var.encrypted}"
+  performance_mode = "${var.performance_mode}"
 }
 
 resource "aws_efs_mount_target" "default" {

--- a/main.tf
+++ b/main.tf
@@ -10,8 +10,8 @@ module "label" {
 }
 
 resource "aws_efs_file_system" "default" {
-  tags = "${module.label.tags}"
-  encrypted = "${var.encrypted}"
+  tags             = "${module.label.tags}"
+  encrypted        = "${var.encrypted}"
   performance_mode = "${var.performance_mode}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -58,3 +58,15 @@ variable "tags" {
   default     = {}
   description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`)"
 }
+
+variable "encrypted" {
+  type        = "string"
+  default     = "false"
+  description = "If true, the disk will be encrypted."
+}
+
+variable "performance_mode" {
+  type        = "string"
+  default     = "generalPurpose"
+  description = "The file system performance mode. Can be either `generalPurpose` or `maxIO`"
+}


### PR DESCRIPTION
## what
* Add support for encryption and performance mode

## why
* These options are now available in [aws_efs_file_system](https://www.terraform.io/docs/providers/aws/r/efs_file_system.html#)