### PR TITLE
Update terraform-null-label module to latest

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 # Define composite variables for resources
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.5"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.7.0"
   enabled    = "${var.enabled}"
   namespace  = "${var.namespace}"
   name       = "${var.name}"


### PR DESCRIPTION
I'd like to update the terraform-null-label version in order to be able to omit the "namespace" parameter.

When creating an EFS volume a CNAME is also created, which is great but that CNAME is prefixed with "${var.namespace}", which defaults to "eg".

I'd like my CNAME to read something more like `$ENV-$NAME-efs.$DOMAIN` rather than `(eg|cp)-$ENV-$NAME-efs.$DOMAIN`

By using the latest version of terraform-null-label, I think I should be able to omit the namespace parameter altogether.