### PR TITLE
add dns_name variable to allow control of CNAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Available targets:
 | availability_zones | Availability Zone IDs | list | - | yes |
 | aws_region | AWS Region | string | - | yes |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
+| dns_name | Name of the CNAME record to create. | string | `` | no |
 | enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
 | encrypted | If true, the disk will be encrypted | string | `false` | no |
 | mount_target_ip_address | The address (within the address range of the specified subnet) at which the file system may be mounted via the mount target | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -6,6 +6,7 @@
 | availability_zones | Availability Zone IDs | list | - | yes |
 | aws_region | AWS Region | string | - | yes |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
+| dns_name | Name of the CNAME record to create. | string | `` | no |
 | enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
 | encrypted | If true, the disk will be encrypted | string | `false` | no |
 | mount_target_ip_address | The address (within the address range of the specified subnet) at which the file system may be mounted via the mount target | string | `` | no |

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "aws_security_group" "default" {
 module "dns" {
   source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.2.5"
   enabled   = "${local.enabled && length(var.zone_id) > 0 ? "true" : "false"}"
-  name      = "${var.dns_name == "" ? module.label.id : "${var.dns_name}"}"
+  name      = "${var.dns_name == "" ? module.label.id : var.dns_name}"
   namespace = "${var.namespace}"
   stage     = "${var.stage}"
   ttl       = 60

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "aws_security_group" "default" {
 module "dns" {
   source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.2.5"
   enabled   = "${local.enabled && length(var.zone_id) > 0 ? "true" : "false"}"
-  name      = "${module.label.id}"
+  name      = "${var.dns_name == "" ? module.label.id : "${var.dns_name}"}"
   namespace = "${var.namespace}"
   stage     = "${var.stage}"
   ttl       = 60

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,6 @@ variable "mount_target_ip_address" {
 
 variable "dns_name" {
   type        = "string"
-  description = "Name of the CNAME record to create.
+  description = "Name of the CNAME record to create."
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -99,3 +99,9 @@ variable "mount_target_ip_address" {
   description = "The address (within the address range of the specified subnet) at which the file system may be mounted via the mount target"
   default     = ""
 }
+
+variable "dns_name" {
+  type        = "string"
+  description = "Name of the CNAME record to create.
+  default     = ""
+}


### PR DESCRIPTION
The creation of the EFS volume's CNAME is currently out of user's control.

This change proposes the option to allow users to set their own DNS name for the volume.

If no name is set, fallback to the current behavior.