### PR TITLE
Fix outputs. Remove redundant `availability_zones` var. Add security group ID and ARN to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,17 +257,17 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 |---|---|---|---|---|---|
 
   [osterman_homepage]: https://github.com/osterman
-  [osterman_avatar]: https://github.com/osterman.png?size=150
+  [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
   [goruha_homepage]: https://github.com/goruha
-  [goruha_avatar]: https://github.com/goruha.png?size=150
+  [goruha_avatar]: https://img.cloudposse.com/150x150/https://github.com/goruha.png
   [aknysh_homepage]: https://github.com/aknysh
-  [aknysh_avatar]: https://github.com/aknysh.png?size=150
+  [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
   [s2504s_homepage]: https://github.com/s2504s
-  [s2504s_avatar]: https://github.com/s2504s.png?size=150
+  [s2504s_avatar]: https://img.cloudposse.com/150x150/https://github.com/s2504s.png
   [maokomioko_homepage]: https://github.com/maokomioko
-  [maokomioko_avatar]: https://github.com/maokomioko.png?size=150
+  [maokomioko_avatar]: https://img.cloudposse.com/150x150/https://github.com/maokomioko.png
   [joshmyers_homepage]: https://github.com/joshmyers
-  [joshmyers_avatar]: https://github.com/joshmyers.png?size=150
+  [joshmyers_avatar]: https://img.cloudposse.com/150x150/https://github.com/joshmyers.png
 
 
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
-| availability_zones | Availability Zone IDs | list(string) | - | yes |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
 | dns_name | Name of the CNAME record to create | string | `` | no |
 | enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
@@ -116,6 +115,9 @@ Available targets:
 | mount_target_ids | List of EFS mount target IDs (one per Availability Zone) |
 | mount_target_ips | List of EFS mount target IPs (one per Availability Zone) |
 | network_interface_ids | List of mount target network interface IDs |
+| security_group_arn | EFS Security Group ARN |
+| security_group_id | EFS Security Group ID |
+| security_group_name | EFS Security Group name |
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,6 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
-| availability_zones | Availability Zone IDs | list(string) | - | yes |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
 | dns_name | Name of the CNAME record to create | string | `` | no |
 | enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
@@ -34,4 +33,7 @@
 | mount_target_ids | List of EFS mount target IDs (one per Availability Zone) |
 | mount_target_ips | List of EFS mount target IPs (one per Availability Zone) |
 | network_interface_ids | List of mount target network interface IDs |
+| security_group_arn | EFS Security Group ARN |
+| security_group_id | EFS Security Group ID |
+| security_group_name | EFS Security Group name |
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.6.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.0"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -11,7 +11,7 @@ module "vpc" {
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.15.0"
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.16.0"
   availability_zones   = var.availability_zones
   namespace            = var.namespace
   stage                = var.stage

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -24,13 +24,12 @@ module "subnets" {
 }
 
 module "efs" {
-  source             = "../../"
-  namespace          = var.namespace
-  stage              = var.stage
-  name               = var.name
-  region             = var.region
-  availability_zones = var.availability_zones
-  vpc_id             = module.vpc.vpc_id
-  subnets            = module.subnets.private_subnet_ids
-  security_groups    = [module.vpc.vpc_default_security_group_id]
+  source          = "../../"
+  namespace       = var.namespace
+  stage           = var.stage
+  name            = var.name
+  region          = var.region
+  vpc_id          = module.vpc.vpc_id
+  subnets         = module.subnets.private_subnet_ids
+  security_groups = [module.vpc.vpc_default_security_group_id]
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -49,3 +49,18 @@ output "efs_network_interface_ids" {
   value       = module.efs.network_interface_ids
   description = "List of mount target network interface IDs"
 }
+
+output "security_group_id" {
+  value       = module.efs.security_group_id
+  description = "EFS Security Group ID"
+}
+
+output "security_group_arn" {
+  value       = module.efs.security_group_arn
+  description = "EFS Security Group ARN"
+}
+
+output "security_group_name" {
+  value       = module.efs.security_group_name
+  description = "EFS Security Group name"
+}

--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "aws_efs_mount_target" "default" {
 resource "aws_security_group" "default" {
   count       = var.enabled ? 1 : 0
   name        = module.label.id
-  description = "EFS"
+  description = "EFS Security Group"
   vpc_id      = var.vpc_id
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.1"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.15.0"
   enabled    = var.enabled
   namespace  = var.namespace
   name       = var.name
@@ -23,7 +23,7 @@ resource "aws_efs_file_system" "default" {
 }
 
 resource "aws_efs_mount_target" "default" {
-  count           = var.enabled && length(var.availability_zones) > 0 ? length(var.availability_zones) : 0
+  count           = var.enabled && length(var.subnets) > 0 ? length(var.subnets) : 0
   file_system_id  = join("", aws_efs_file_system.default.*.id)
   ip_address      = var.mount_target_ip_address
   subnet_id       = var.subnets[count.index]

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,21 +19,21 @@ output "dns_name" {
 }
 
 output "mount_target_dns_names" {
-  value       = [coalescelist(aws_efs_mount_target.default.*.dns_name, [""])]
+  value       = coalescelist(aws_efs_mount_target.default.*.dns_name, [""])
   description = "List of EFS mount target DNS names"
 }
 
 output "mount_target_ids" {
-  value       = [coalescelist(aws_efs_mount_target.default.*.id, [""])]
+  value       = coalescelist(aws_efs_mount_target.default.*.id, [""])
   description = "List of EFS mount target IDs (one per Availability Zone)"
 }
 
 output "mount_target_ips" {
-  value       = [coalescelist(aws_efs_mount_target.default.*.ip_address, [""])]
+  value       = coalescelist(aws_efs_mount_target.default.*.ip_address, [""])
   description = "List of EFS mount target IPs (one per Availability Zone)"
 }
 
 output "network_interface_ids" {
-  value       = [coalescelist(aws_efs_mount_target.default.*.network_interface_id, [""])]
+  value       = coalescelist(aws_efs_mount_target.default.*.network_interface_id, [""])
   description = "List of mount target network interface IDs"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,18 @@ output "network_interface_ids" {
   value       = coalescelist(aws_efs_mount_target.default.*.network_interface_id, [""])
   description = "List of mount target network interface IDs"
 }
+
+output "security_group_id" {
+  value       = join("", aws_security_group.default.*.id)
+  description = "EFS Security Group ID"
+}
+
+output "security_group_arn" {
+  value       = join("", aws_security_group.default.*.arn)
+  description = "EFS Security Group ARN"
+}
+
+output "security_group_name" {
+  value       = join("", aws_security_group.default.*.name)
+  description = "EFS Security Group name"
+}

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -27,28 +27,24 @@ func TestExamplesComplete(t *testing.T) {
 
 	// Run `terraform output` to get the value of an output variable
 	vpcCidr := terraform.Output(t, terraformOptions, "vpc_cidr")
-
 	expectedVpcCidr := "172.16.0.0/16"
 	// Verify we're getting back the outputs we expect
 	assert.Equal(t, expectedVpcCidr, vpcCidr)
 
 	// Run `terraform output` to get the value of an output variable
 	privateSubnetCidrs := terraform.OutputList(t, terraformOptions, "private_subnet_cidrs")
-
 	expectedPrivateSubnetCidrs := []string{"172.16.0.0/18", "172.16.64.0/18"}
 	// Verify we're getting back the outputs we expect
 	assert.Equal(t, expectedPrivateSubnetCidrs, privateSubnetCidrs)
 
 	// Run `terraform output` to get the value of an output variable
 	publicSubnetCidrs := terraform.OutputList(t, terraformOptions, "public_subnet_cidrs")
-
 	expectedPublicSubnetCidrs := []string{"172.16.128.0/18", "172.16.192.0/18"}
 	// Verify we're getting back the outputs we expect
 	assert.Equal(t, expectedPublicSubnetCidrs, publicSubnetCidrs)
 
 	// Run `terraform output` to get the value of an output variable
 	efsArn := terraform.Output(t, terraformOptions, "efs_arn")
-
 	// Verify we're getting back the outputs we expect, e.g. arn:aws:elasticfilesystem:us-west-1:126450723953:file-system/fs-0ce26015
 	assert.Contains(t, efsArn, "arn:aws:elasticfilesystem:us-west-1:126450723953:file-system/")
 }

--- a/variables.tf
+++ b/variables.tf
@@ -41,11 +41,6 @@ variable "subnets" {
   description = "Subnet IDs"
 }
 
-variable "availability_zones" {
-  type        = list(string)
-  description = "Availability Zone IDs"
-}
-
 variable "zone_id" {
   type        = string
   description = "Route53 DNS zone ID"


### PR DESCRIPTION
## what
* Fix outputs
* Remove redundant `availability_zones` var
* Add security group ID and ARN to outputs

## why
* TF 0.12 does not support list of lists (does not flatten `[]` if it contains another list)
* Closes #29 
* Closes #30 
