### PR TITLE
Kms key support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,7 @@ resource "aws_efs_file_system" "default" {
   count                           = var.enabled ? 1 : 0
   tags                            = module.label.tags
   encrypted                       = var.encrypted
+  kms_key_id                      = var.kms_key_id
   performance_mode                = var.performance_mode
   provisioned_throughput_in_mibps = var.provisioned_throughput_in_mibps
   throughput_mode                 = var.throughput_mode

--- a/variables.tf
+++ b/variables.tf
@@ -78,6 +78,12 @@ variable "encrypted" {
   default     = false
 }
 
+variable "kms_key_id" {
+  type        = string
+  description = "The ARN for the KMS encryption key to use"
+  default     = null
+}
+
 variable "performance_mode" {
   type        = string
   description = "The file system performance mode. Can be either `generalPurpose` or `maxIO`"


### PR DESCRIPTION
Adding support to set the KMS key, as discussed in #36 running `make readme` appears to remove all the inputs/outputs from the readme.