### PR TITLE
Add option to allow ingress traffic from CIDR blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,47 +118,64 @@ Available targets:
   lint                                Lint terraform code
 
 ```
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.0 |
+| aws | ~> 2.0 |
+| local | ~> 1.2 |
+| null | ~> 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2.0 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
-| delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | string | `-` | no |
-| dns_name | Name of the CNAME record to create | string | `` | no |
-| enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
-| encrypted | If true, the file system will be encrypted | bool | `false` | no |
-| environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | string | `` | no |
-| kms_key_id | If set, use a specific KMS key | string | `null` | no |
-| mount_target_ip_address | The address (within the address range of the specified subnet) at which the file system may be mounted via the mount target | string | `` | no |
-| name | Solution name, e.g. 'app' or 'jenkins' | string | `` | no |
-| namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | string | `` | no |
-| performance_mode | The file system performance mode. Can be either `generalPurpose` or `maxIO` | string | `generalPurpose` | no |
-| provisioned_throughput_in_mibps | The throughput, measured in MiB/s, that you want to provision for the file system. Only applicable with `throughput_mode` set to provisioned | string | `0` | no |
-| region | AWS Region | string | - | yes |
-| security_groups | Security group IDs to allow access to the EFS | list(string) | - | yes |
-| stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | string | `` | no |
-| subnets | Subnet IDs | list(string) | - | yes |
-| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | map(string) | `<map>` | no |
-| throughput_mode | Throughput mode for the file system. Defaults to bursting. Valid values: `bursting`, `provisioned`. When using `provisioned`, also set `provisioned_throughput_in_mibps` | string | `bursting` | no |
-| transition_to_ia | Indicates how long it takes to transition files to the IA storage class. Valid values: AFTER_7_DAYS, AFTER_14_DAYS, AFTER_30_DAYS, AFTER_60_DAYS and AFTER_90_DAYS | string | `` | no |
-| vpc_id | VPC ID | string | - | yes |
-| zone_id | Route53 DNS zone ID | string | `` | no |
+|------|-------------|------|---------|:--------:|
+| attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
+| dns\_name | Name of the CNAME record to create | `string` | `""` | no |
+| enabled | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
+| encrypted | If true, the file system will be encrypted | `bool` | `false` | no |
+| environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
+| kms\_key\_id | If set, use a specific KMS key | `string` | `null` | no |
+| mount\_target\_ip\_address | The address (within the address range of the specified subnet) at which the file system may be mounted via the mount target | `string` | `""` | no |
+| name | Solution name, e.g. 'app' or 'jenkins' | `string` | `""` | no |
+| namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `""` | no |
+| performance\_mode | The file system performance mode. Can be either `generalPurpose` or `maxIO` | `string` | `"generalPurpose"` | no |
+| provisioned\_throughput\_in\_mibps | The throughput, measured in MiB/s, that you want to provision for the file system. Only applicable with `throughput_mode` set to provisioned | `number` | `0` | no |
+| region | AWS Region | `string` | n/a | yes |
+| security\_group\_cidr\_blocks | A list of CIDR blocks to add to the ingress rule to allow access to the EFS | `list(string)` | `[]` | no |
+| security\_groups | Security group IDs to allow access to the EFS | `list(string)` | n/a | yes |
+| stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `""` | no |
+| subnets | Subnet IDs | `list(string)` | n/a | yes |
+| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+| throughput\_mode | Throughput mode for the file system. Defaults to bursting. Valid values: `bursting`, `provisioned`. When using `provisioned`, also set `provisioned_throughput_in_mibps` | `string` | `"bursting"` | no |
+| transition\_to\_ia | Indicates how long it takes to transition files to the IA storage class. Valid values: AFTER\_7\_DAYS, AFTER\_14\_DAYS, AFTER\_30\_DAYS, AFTER\_60\_DAYS and AFTER\_90\_DAYS | `string` | `""` | no |
+| use\_security\_group\_cidr\_blocks | A flag to enable/disable adding a security group rule for ingress access to the EFS from CIDR blocks | `bool` | `false` | no |
+| vpc\_id | VPC ID | `string` | n/a | yes |
+| zone\_id | Route53 DNS zone ID | `string` | `""` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | arn | EFS ARN |
-| dns_name | EFS DNS name |
+| dns\_name | EFS DNS name |
 | host | Route53 DNS hostname for the EFS |
 | id | EFS ID |
-| mount_target_dns_names | List of EFS mount target DNS names |
-| mount_target_ids | List of EFS mount target IDs (one per Availability Zone) |
-| mount_target_ips | List of EFS mount target IPs (one per Availability Zone) |
-| network_interface_ids | List of mount target network interface IDs |
-| security_group_arn | EFS Security Group ARN |
-| security_group_id | EFS Security Group ID |
-| security_group_name | EFS Security Group name |
+| mount\_target\_dns\_names | List of EFS mount target DNS names |
+| mount\_target\_ids | List of EFS mount target IDs (one per Availability Zone) |
+| mount\_target\_ips | List of EFS mount target IPs (one per Availability Zone) |
+| network\_interface\_ids | List of mount target network interface IDs |
+| security\_group\_arn | EFS Security Group ARN |
+| security\_group\_id | EFS Security Group ID |
+| security\_group\_name | EFS Security Group name |
 
 
 
@@ -212,6 +229,10 @@ We deliver 10x the value for a fraction of the cost of a full-time engineer. Our
 ## Slack Community
 
 Join our [Open Source Community][slack] on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
+
+## Discourse Forums
+
+Participate in our [Discourse Forums][discourse]. Here you'll find answers to commonly asked questions. Most questions will be related to the enormous number of projects we support on our GitHub. Come here to collaborate on answers, find solutions, and get ideas about the products and services we value. It only takes a minute to get started! Just sign in with SSO using your GitHub account.
 
 ## Newsletter
 
@@ -332,6 +353,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [testimonial]: https://cpco.io/leave-testimonial?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-efs&utm_content=testimonial
   [office_hours]: https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-efs&utm_content=office_hours
   [newsletter]: https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-efs&utm_content=newsletter
+  [discourse]: https://ask.sweetops.com/?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-efs&utm_content=discourse
   [email]: https://cpco.io/email?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-efs&utm_content=email
   [commercial_support]: https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-efs&utm_content=commercial_support
   [we_love_open_source]: https://cpco.io/we-love-open-source?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-efs&utm_content=we_love_open_source

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,42 +1,59 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.0 |
+| aws | ~> 2.0 |
+| local | ~> 1.2 |
+| null | ~> 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2.0 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
-| delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | string | `-` | no |
-| dns_name | Name of the CNAME record to create | string | `` | no |
-| enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
-| encrypted | If true, the file system will be encrypted | bool | `false` | no |
-| environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | string | `` | no |
-| kms_key_id | If set, use a specific KMS key | string | `null` | no |
-| mount_target_ip_address | The address (within the address range of the specified subnet) at which the file system may be mounted via the mount target | string | `` | no |
-| name | Solution name, e.g. 'app' or 'jenkins' | string | `` | no |
-| namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | string | `` | no |
-| performance_mode | The file system performance mode. Can be either `generalPurpose` or `maxIO` | string | `generalPurpose` | no |
-| provisioned_throughput_in_mibps | The throughput, measured in MiB/s, that you want to provision for the file system. Only applicable with `throughput_mode` set to provisioned | string | `0` | no |
-| region | AWS Region | string | - | yes |
-| security_groups | Security group IDs to allow access to the EFS | list(string) | - | yes |
-| stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | string | `` | no |
-| subnets | Subnet IDs | list(string) | - | yes |
-| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | map(string) | `<map>` | no |
-| throughput_mode | Throughput mode for the file system. Defaults to bursting. Valid values: `bursting`, `provisioned`. When using `provisioned`, also set `provisioned_throughput_in_mibps` | string | `bursting` | no |
-| transition_to_ia | Indicates how long it takes to transition files to the IA storage class. Valid values: AFTER_7_DAYS, AFTER_14_DAYS, AFTER_30_DAYS, AFTER_60_DAYS and AFTER_90_DAYS | string | `` | no |
-| vpc_id | VPC ID | string | - | yes |
-| zone_id | Route53 DNS zone ID | string | `` | no |
+|------|-------------|------|---------|:--------:|
+| attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
+| dns\_name | Name of the CNAME record to create | `string` | `""` | no |
+| enabled | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
+| encrypted | If true, the file system will be encrypted | `bool` | `false` | no |
+| environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
+| kms\_key\_id | If set, use a specific KMS key | `string` | `null` | no |
+| mount\_target\_ip\_address | The address (within the address range of the specified subnet) at which the file system may be mounted via the mount target | `string` | `""` | no |
+| name | Solution name, e.g. 'app' or 'jenkins' | `string` | `""` | no |
+| namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `""` | no |
+| performance\_mode | The file system performance mode. Can be either `generalPurpose` or `maxIO` | `string` | `"generalPurpose"` | no |
+| provisioned\_throughput\_in\_mibps | The throughput, measured in MiB/s, that you want to provision for the file system. Only applicable with `throughput_mode` set to provisioned | `number` | `0` | no |
+| region | AWS Region | `string` | n/a | yes |
+| security\_group\_cidr\_blocks | A list of CIDR blocks to add to the ingress rule to allow access to the EFS | `list(string)` | `[]` | no |
+| security\_groups | Security group IDs to allow access to the EFS | `list(string)` | n/a | yes |
+| stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `""` | no |
+| subnets | Subnet IDs | `list(string)` | n/a | yes |
+| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+| throughput\_mode | Throughput mode for the file system. Defaults to bursting. Valid values: `bursting`, `provisioned`. When using `provisioned`, also set `provisioned_throughput_in_mibps` | `string` | `"bursting"` | no |
+| transition\_to\_ia | Indicates how long it takes to transition files to the IA storage class. Valid values: AFTER\_7\_DAYS, AFTER\_14\_DAYS, AFTER\_30\_DAYS, AFTER\_60\_DAYS and AFTER\_90\_DAYS | `string` | `""` | no |
+| use\_security\_group\_cidr\_blocks | A flag to enable/disable adding a security group rule for ingress access to the EFS from CIDR blocks | `bool` | `false` | no |
+| vpc\_id | VPC ID | `string` | n/a | yes |
+| zone\_id | Route53 DNS zone ID | `string` | `""` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | arn | EFS ARN |
-| dns_name | EFS DNS name |
+| dns\_name | EFS DNS name |
 | host | Route53 DNS hostname for the EFS |
 | id | EFS ID |
-| mount_target_dns_names | List of EFS mount target DNS names |
-| mount_target_ids | List of EFS mount target IDs (one per Availability Zone) |
-| mount_target_ips | List of EFS mount target IPs (one per Availability Zone) |
-| network_interface_ids | List of mount target network interface IDs |
-| security_group_arn | EFS Security Group ARN |
-| security_group_id | EFS Security Group ID |
-| security_group_name | EFS Security Group name |
+| mount\_target\_dns\_names | List of EFS mount target DNS names |
+| mount\_target\_ids | List of EFS mount target IDs (one per Availability Zone) |
+| mount\_target\_ips | List of EFS mount target IPs (one per Availability Zone) |
+| network\_interface\_ids | List of mount target network interface IDs |
+| security\_group\_arn | EFS Security Group ARN |
+| security\_group\_id | EFS Security Group ID |
+| security\_group\_name | EFS Security Group name |
 

--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,16 @@ resource "aws_security_group" "efs" {
   tags = module.label.tags
 }
 
+resource "aws_security_group_rule" "efs_cidr" {
+  count = var.enabled && var.use_security_group_cidr_blocks ? 1 : 0
+  type              = "ingress"
+  from_port         = "2049" # NFS
+  to_port           = "2049"
+  protocol          = "tcp"
+  cidr_blocks       = var.security_group_cidr_blocks
+  security_group_id = join("", aws_security_group.efs.*.id)
+}
+
 resource "aws_security_group_rule" "ingress" {
   count                    = var.enabled ? length(var.security_groups) : 0
   type                     = "ingress"

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ resource "aws_security_group" "efs" {
 }
 
 resource "aws_security_group_rule" "efs_cidr" {
-  count = var.enabled && var.use_security_group_cidr_blocks ? 1 : 0
+  count             = var.enabled && var.use_security_group_cidr_blocks ? 1 : 0
   type              = "ingress"
   from_port         = "2049" # NFS
   to_port           = "2049"

--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,6 @@ resource "aws_security_group" "efs" {
   tags = module.label.tags
 }
 
-
 resource "aws_security_group_rule" "ingress" {
   count                    = var.enabled ? length(var.security_groups) : 0
   type                     = "ingress"

--- a/main.tf
+++ b/main.tf
@@ -52,15 +52,6 @@ resource "aws_security_group" "efs" {
   tags = module.label.tags
 }
 
-resource "aws_security_group_rule" "efs_cidr" {
-  count             = var.enabled && var.use_security_group_cidr_blocks ? 1 : 0
-  type              = "ingress"
-  from_port         = "2049" # NFS
-  to_port           = "2049"
-  protocol          = "tcp"
-  cidr_blocks       = var.security_group_cidr_blocks
-  security_group_id = join("", aws_security_group.efs.*.id)
-}
 
 resource "aws_security_group_rule" "ingress" {
   count                    = var.enabled ? length(var.security_groups) : 0
@@ -70,6 +61,16 @@ resource "aws_security_group_rule" "ingress" {
   protocol                 = "tcp"
   source_security_group_id = var.security_groups[count.index]
   security_group_id        = join("", aws_security_group.efs.*.id)
+}
+
+resource "aws_security_group_rule" "cidr_ingress" {
+  count             = var.enabled && var.use_security_group_cidr_blocks ? 1 : 0
+  type              = "ingress"
+  from_port         = "2049" # NFS
+  to_port           = "2049"
+  protocol          = "tcp"
+  cidr_blocks       = var.security_group_cidr_blocks
+  security_group_id = join("", aws_security_group.efs.*.id)
 }
 
 resource "aws_security_group_rule" "egress" {

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,18 @@ variable "security_groups" {
   description = "Security group IDs to allow access to the EFS"
 }
 
+variable "use_security_group_cidr_blocks" {
+  type        = bool
+  description = "A flag to enable/disable adding a security group rule for ingress access to the EFS from CIDR blocks"
+  default     = false
+}
+
+variable "security_group_cidr_blocks" {
+  type        = list(string)
+  description = "A list of CIDR blocks to add to the ingress rule to allow access to the EFS"
+  default     = []
+}
+
 variable "vpc_id" {
   type        = string
   description = "VPC ID"


### PR DESCRIPTION
## what
* Adds the option to allow ingress traffic to EFS from arbitrary CIDR blocks

## why
* As-is this module appears to only support traffic from source security groups. This change allows traffic from arbitrary IP ranges (in my case from a non AWS resource that won't have a security group attached)


