### PR TITLE
* Update mount_target_ip_address variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -104,7 +104,7 @@ variable "throughput_mode" {
 variable "mount_target_ip_address" {
   type        = string
   description = "The address (within the address range of the specified subnet) at which the file system may be mounted via the mount target"
-  default     = ""
+  default     = null
 }
 
 variable "dns_name" {


### PR DESCRIPTION
## what
* mount_target_ip_address variable is now by default equals to null 

## why
* Error: expected ip_address to contain a valid IPv4 address, got: 
   on .terraform/modules/efs/main.tf line 26, in resource "aws_efs_mount_target" "default":
* terraform cannot validate an empty string as value of IPv4 address

## references
* https://github.com/terraform-providers/terraform-provider-aws/issues/13626
* closes #44 


