### PR TITLE
update AWS provider pinning

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws   = "~> 3.0"
+    aws   = ">= 3.0, < 4.0"
     local = "~> 1.2"
     null  = "~> 2.0"
   }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws   = "~> 2.0"
+    aws   = "~> 3.0"
     local = "~> 1.2"
     null  = "~> 2.0"
   }


### PR DESCRIPTION
## what
do not restrict the aws provider version to just v2

## why
https://github.com/cloudposse/terraform-aws-route53-cluster-hostname/issues/23
the aws cloud provider has v13 fixes and requirements also

## references
`closes #52`
https://github.com/cloudposse/terraform-aws-efs/issues/52