### PR TITLE
Update terraform-aws-route53-cluster-hostname to 0.7.0 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -73,7 +73,7 @@ resource "aws_security_group_rule" "egress" {
 }
 
 module "dns" {
-  source = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.6.0"
+  source = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.7.0"
 
   enabled = module.this.enabled && length(var.zone_id) > 0 ? true : false
   name    = var.dns_name == "" ? module.this.id : var.dns_name


### PR DESCRIPTION
## what
* Update terraform-aws-route53-cluster-hostname to 0.7.0


## why
* 0.6.0 introduced a bug where you could not overwrite the hostname


## references
* https://github.com/cloudposse/terraform-aws-route53-cluster-hostname/commit/abd24152b4b9acd4a1f595db3591449139e03b6e

