### PR TITLE
fix mount_target_dns_names output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -29,7 +29,7 @@ output "dns_name" {
 }
 
 output "mount_target_dns_names" {
-  value       = coalescelist(aws_efs_mount_target.default.*.dns_name, [""])
+  value       = coalescelist(aws_efs_mount_target.default.*.mount_target_dns_name, [""])
   description = "List of EFS mount target DNS names"
 }
 


### PR DESCRIPTION
## why
The `mount_target_dns_names` output contains only the efs dns name, without the availability zone

## references
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_mount_target
