### PR TITLE
make this module v14 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
+<!-- markdownlint-disable -->
 # terraform-aws-efs [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-efs.svg)](https://github.com/cloudposse/terraform-aws-efs/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+<!-- markdownlint-restore -->
 
 [![README Header][readme_header_img]][readme_header_link]
 
@@ -70,7 +72,9 @@ Include this repository as a module in your existing terraform code:
 
 ```hcl
 module "efs" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-efs.git?ref=master"
+  source = "cloudposse/efs/aws"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version     = "x.x.x"
 
   namespace          = "eg"
   stage              = "test"
@@ -105,7 +109,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.0 |
 | local | >= 1.2 |
 | null | >= 2.0 |
@@ -315,8 +319,10 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 ### Contributors
 
+<!-- markdownlint-disable -->
 |  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Sergey Vasilyev][s2504s_avatar]][s2504s_homepage]<br/>[Sergey Vasilyev][s2504s_homepage] | [![Mike Eirih][maokomioko_avatar]][maokomioko_homepage]<br/>[Mike Eirih][maokomioko_homepage] | [![Josh Myers][joshmyers_avatar]][joshmyers_homepage]<br/>[Josh Myers][joshmyers_homepage] |
 |---|---|---|---|---|---|
+<!-- markdownlint-restore -->
 
   [osterman_homepage]: https://github.com/osterman
   [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png

--- a/README.yaml
+++ b/README.yaml
@@ -47,7 +47,9 @@ usage: |-
 
   ```hcl
   module "efs" {
-    source     = "git::https://github.com/cloudposse/terraform-aws-efs.git?ref=master"
+    source = "cloudposse/efs/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version     = "x.x.x"
 
     namespace          = "eg"
     stage              = "test"

--- a/context.tf
+++ b/context.tf
@@ -19,7 +19,7 @@
 #
 
 module "this" {
-   source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
+   source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0"
 
   enabled             = var.enabled
   namespace           = var.namespace

--- a/context.tf
+++ b/context.tf
@@ -19,7 +19,8 @@
 #
 
 module "this" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.22.0"
+  source              = "cloudposse/label/null"
+  version             = "0.22.0"
 
   enabled             = var.enabled
   namespace           = var.namespace

--- a/context.tf
+++ b/context.tf
@@ -19,7 +19,7 @@
 #
 
 module "this" {
-   source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.22.0"
+  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.22.0"
 
   enabled             = var.enabled
   namespace           = var.namespace

--- a/context.tf
+++ b/context.tf
@@ -19,7 +19,7 @@
 #
 
 module "this" {
-   source = "git::ssh://git@github.com/jurgenweber/terraform-null-label.git?ref=master"
+   source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
 
   enabled             = var.enabled
   namespace           = var.namespace

--- a/context.tf
+++ b/context.tf
@@ -19,7 +19,7 @@
 #
 
 module "this" {
-   source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0"
+   source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.22.0"
 
   enabled             = var.enabled
   namespace           = var.namespace

--- a/context.tf
+++ b/context.tf
@@ -19,7 +19,7 @@
 #
 
 module "this" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
+   source = "git::ssh://git@github.com/jurgenweber/terraform-null-label.git?ref=master"
 
   enabled             = var.enabled
   namespace           = var.namespace

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.0 |
 | local | >= 1.2 |
 | null | >= 2.0 |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,7 +3,8 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.17.0"
+  source  = "cloudposse/vpc/aws"
+  version = "0.17.0"
 
   cidr_block = "172.16.0.0/16"
 
@@ -11,7 +12,8 @@ module "vpc" {
 }
 
 module "subnets" {
-  source = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.28.0"
+  source  = "cloudposse/dynamic-subnets/aws"
+  version = "0.28.0"
 
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 module "vpc" {
   source  = "cloudposse/vpc/aws"
-  version = "0.17.0"
+  version = "0.18.1"
 
   cidr_block = "172.16.0.0/16"
 
@@ -13,7 +13,7 @@ module "vpc" {
 
 module "subnets" {
   source  = "cloudposse/dynamic-subnets/aws"
-  version = "0.28.0"
+  version = "0.33.0"
 
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,9 +1,18 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.26"
 
   required_providers {
-    aws   = ">= 2.0"
-    local = ">= 1.2"
-    null  = ">= 2.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.2"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,8 @@ resource "aws_security_group_rule" "egress" {
 }
 
 module "dns" {
-  source = "git::ssh://git@github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=0.7.0"
+  # source = "git::ssh://git@github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=0.7.0"
+  source = "git::https://git@github.com/jurgenweber/terraform-aws-route53-cluster-hostname.git?ref=master"
 
   enabled  = module.this.enabled && length(var.zone_id) > 0 ? true : false
   dns_name = var.dns_name == "" ? module.this.id : var.dns_name

--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,7 @@ resource "aws_security_group_rule" "egress" {
 }
 
 module "dns" {
-  source = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.7.0"
+  source = "git::ssh://git@github.com/jurgenweber/terraform-aws-route53-cluster-hostname.git?ref=master"
 
   enabled  = module.this.enabled && length(var.zone_id) > 0 ? true : false
   dns_name = var.dns_name == "" ? module.this.id : var.dns_name

--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,8 @@ resource "aws_security_group_rule" "egress" {
 }
 
 module "dns" {
-  source = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.8.0"
+  source  = "cloudposse/route53-cluster-hostname/aws"
+  version = "0.8.0"
 
   enabled  = module.this.enabled && length(var.zone_id) > 0 ? true : false
   dns_name = var.dns_name == "" ? module.this.id : var.dns_name

--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,7 @@ resource "aws_security_group_rule" "egress" {
 }
 
 module "dns" {
-  source = "git::ssh://git@github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=0.8.0"
+  source = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.8.0"
 
   enabled  = module.this.enabled && length(var.zone_id) > 0 ? true : false
   dns_name = var.dns_name == "" ? module.this.id : var.dns_name

--- a/main.tf
+++ b/main.tf
@@ -97,8 +97,7 @@ resource "aws_security_group_rule" "egress" {
 }
 
 module "dns" {
-  # source = "git::ssh://git@github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=0.7.0"
-  source = "git::https://git@github.com/jurgenweber/terraform-aws-route53-cluster-hostname.git?ref=master"
+  source = "git::ssh://git@github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=0.8.0"
 
   enabled  = module.this.enabled && length(var.zone_id) > 0 ? true : false
   dns_name = var.dns_name == "" ? module.this.id : var.dns_name

--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,7 @@ resource "aws_security_group_rule" "egress" {
 }
 
 module "dns" {
-  source = "git::ssh://git@github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=v0.7.0"
+  source = "git::ssh://git@github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=0.7.0"
 
   enabled  = module.this.enabled && length(var.zone_id) > 0 ? true : false
   dns_name = var.dns_name == "" ? module.this.id : var.dns_name

--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,7 @@ resource "aws_security_group_rule" "egress" {
 }
 
 module "dns" {
-  source = "git::ssh://git@github.com/jurgenweber/terraform-aws-route53-cluster-hostname.git?ref=master"
+  source = "git::ssh://git@github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=v0.7.0"
 
   enabled  = module.this.enabled && length(var.zone_id) > 0 ? true : false
   dns_name = var.dns_name == "" ? module.this.id : var.dns_name

--- a/main.tf
+++ b/main.tf
@@ -100,7 +100,6 @@ module "dns" {
   source  = "cloudposse/route53-cluster-hostname/aws"
   version = "0.9.0"
 
-
   enabled  = module.this.enabled && length(var.zone_id) > 0 ? true : false
   dns_name = var.dns_name == "" ? module.this.id : var.dns_name
   ttl      = 60

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,18 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.26"
 
   required_providers {
-    aws   = ">= 2.0"
-    local = ">= 1.2"
-    null  = ">= 2.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.2"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
   }
 }


### PR DESCRIPTION
## what
- Upgrade to support Terraform 0.14 and bring up to current Cloud Posse standard

## why
- Support Terraform 0.14

supersedes and closes #65 