### PR TITLE
Update terraform-aws-route53-cluster-hostname version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,7 @@ resource "aws_security_group_rule" "egress" {
 }
 
 module "dns" {
-  source = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.7.0"
+  source = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.9.0"
 
   enabled  = module.this.enabled && length(var.zone_id) > 0 ? true : false
   dns_name = var.dns_name == "" ? module.this.id : var.dns_name


### PR DESCRIPTION
## what
* Update terraform-aws-route53-cluster-hostname version

## why
* For Terraform 0.14 compatibility 

