### PR TITLE
Make posix_user and creation_info optional in aws_efs_access_point

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "aws_efs_access_point" "default" {
   file_system_id = join("", aws_efs_file_system.default.*.id)
 
   dynamic "posix_user" {
-    for_each = try(lookup(var.access_points[each.key]["posix_user"]["gid"],""),"") != "" ? ["true"] : []
+    for_each = try(lookup(var.access_points[each.key]["posix_user"]["gid"], ""), "") != "" ? ["true"] : []
 
     content {
       gid = var.access_points[each.key]["posix_user"]["gid"]
@@ -53,7 +53,7 @@ resource "aws_efs_access_point" "default" {
     path = "/${each.key}"
 
     dynamic "creation_info" {
-      for_each = try(lookup(var.access_points[each.key]["creation_info"]["gid"],""),"") != "" ? ["true"] : []
+      for_each = try(lookup(var.access_points[each.key]["creation_info"]["gid"], ""), "") != "" ? ["true"] : []
 
       content {
         owner_gid   = var.access_points[each.key]["creation_info"]["gid"]

--- a/main.tf
+++ b/main.tf
@@ -38,19 +38,28 @@ resource "aws_efs_access_point" "default" {
 
   file_system_id = join("", aws_efs_file_system.default.*.id)
 
-  posix_user {
-    gid = var.access_points[each.key]["posix_user"]["gid"]
-    uid = var.access_points[each.key]["posix_user"]["uid"]
-    # Just returning null in the lookup function gives type errors and is not omitting the parameter, this work around ensures null is returned.
-    secondary_gids = lookup(lookup(var.access_points[each.key], "posix_user", {}), "secondary_gids", null) == null ? null : null
+  dynamic "posix_user" {
+    for_each = try(lookup(var.access_points[each.key]["posix_user"]["gid"],""),"") != "" ? ["true"] : []
+
+    content {
+      gid = var.access_points[each.key]["posix_user"]["gid"]
+      uid = var.access_points[each.key]["posix_user"]["uid"]
+      # Just returning null in the lookup function gives type errors and is not omitting the parameter, this work around ensures null is returned.
+      secondary_gids = lookup(lookup(var.access_points[each.key], "posix_user", {}), "secondary_gids", null) == null ? null : null
+    }
   }
 
   root_directory {
     path = "/${each.key}"
-    creation_info {
-      owner_gid   = var.access_points[each.key]["creation_info"]["gid"]
-      owner_uid   = var.access_points[each.key]["creation_info"]["uid"]
-      permissions = var.access_points[each.key]["creation_info"]["permissions"]
+
+    dynamic "creation_info" {
+      for_each = try(lookup(var.access_points[each.key]["creation_info"]["gid"],""),"") != "" ? ["true"] : []
+
+      content {
+        owner_gid   = var.access_points[each.key]["creation_info"]["gid"]
+        owner_uid   = var.access_points[each.key]["creation_info"]["uid"]
+        permissions = var.access_points[each.key]["creation_info"]["permissions"]
+      }
     }
   }
 


### PR DESCRIPTION
## what
- Currently, the EFS module can only accept a fully defined "access_point" with posix_user and creation_info, while those options are actually optional in AWS

## why
- Because those options are optional, and can actually break the functionality by restricting by user ids


