### PR TITLE
Fix: No transition* vars results in an empty lifecycle

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -71,6 +71,8 @@ module "efs" {
     }
   ]
 
+  transition_to_ia = ["AFTER_7_DAYS"]
+
   security_group_create_before_destroy = false
 
   context = module.this.context

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -71,8 +71,6 @@ module "efs" {
     }
   ]
 
-  transition_to_ia = ["AFTER_7_DAYS"]
-
   security_group_create_before_destroy = false
 
   context = module.this.context

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ resource "aws_efs_file_system" "default" {
   throughput_mode                 = var.throughput_mode
 
   dynamic "lifecycle_policy" {
-    for_each = length(var.transition_to_ia) > 0 || length(var.transition_to_primary_storage_class) > 0 ? [1] : [0]
+    for_each = length(var.transition_to_ia) > 0 || length(var.transition_to_primary_storage_class) > 0 ? [1] : []
     content {
       transition_to_ia                    = try(var.transition_to_ia[0], null)
       transition_to_primary_storage_class = try(var.transition_to_primary_storage_class[0], null)

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,4 @@
-locals { 
+locals {
   enabled                = module.this.enabled
   security_group_enabled = local.enabled && var.create_security_group
 

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,4 @@
-locals {
+locals { 
   enabled                = module.this.enabled
   security_group_enabled = local.enabled && var.create_security_group
 


### PR DESCRIPTION
## what
* No lifecycle

## why
* If no transition* var is set, it will throw an error because it results in an empty `lifecycle {}`

## references
* Previous PR https://github.com/cloudposse/terraform-aws-efs/pull/94

