### PR TITLE
Fix bug with root directory cration permissions (#100)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,7 @@ resource "aws_efs_access_point" "default" {
     path = "/${each.key}"
 
     dynamic "creation_info" {
-      for_each = try(lookup(var.access_points[each.key]["creation_info"]["gid"], ""), "") != "" ? ["true"] : []
+      for_each = try(var.access_points[each.key]["creation_info"]["gid"], "") != "" ? ["true"] : []
 
       content {
         owner_gid   = var.access_points[each.key]["creation_info"]["gid"]


### PR DESCRIPTION
## what
* Fix bug with root directory cration permissions (#100)
* lookup() function has been removed with this commit, it will be working also without it because of used try() function

## why
* Tere was changed behavior of lookup() function in terraform. Right now it takes three instead of two parameters.

## references
* https://github.com/cloudposse/terraform-aws-efs/issues/100

