### PR TITLE
Fix: Put lifecycle policies in separate blocks

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,9 +27,15 @@ resource "aws_efs_file_system" "default" {
   throughput_mode                 = var.throughput_mode
 
   dynamic "lifecycle_policy" {
-    for_each = length(var.transition_to_ia) > 0 || length(var.transition_to_primary_storage_class) > 0 ? [1] : []
+    for_each = length(var.transition_to_ia) > 0 ? [1] : []
     content {
       transition_to_ia                    = try(var.transition_to_ia[0], null)
+    }
+  }
+
+  dynamic "lifecycle_policy" {
+    for_each = length(var.transition_to_primary_storage_class) > 0 ? [1] : []
+    content {
       transition_to_primary_storage_class = try(var.transition_to_primary_storage_class[0], null)
     }
   }


### PR DESCRIPTION
## what
* Splits `transition_to_ia` and `transition_to_primary_storage_class` into separate dynamic `lifecycle_policy` blocks.

## why
* Using both `transition_to_ia` and `transition_to_primary_storage_class` breaks the module because Terraform expects separate `lifecycle_policy` blocks.

## references
#103
