### PR TITLE
Associated Security Groups doesn't work #102

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -32,48 +32,34 @@ module "efs" {
   vpc_id  = module.vpc.vpc_id
   subnets = module.subnets.private_subnet_ids
 
-  access_points = {
-    "data" = {
-      posix_user = {
-        gid            = "1001"
-        uid            = "5000"
-        secondary_gids = "1002,1003"
-      }
-      creation_info = {
-        gid         = "1001"
-        uid         = "5000"
-        permissions = "0755"
-      }
-    }
-    "data2" = {
-      posix_user = {
-        gid            = "2001"
-        uid            = "6000"
-        secondary_gids = null
-      }
-      creation_info = {
-        gid         = "123"
-        uid         = "222"
-        permissions = "0555"
-      }
-    }
-  }
+  efs_backup_policy_enabled       = true
 
-  additional_security_group_rules = [
-    {
-      type                     = "ingress"
-      from_port                = 2049
-      to_port                  = 2049
-      protocol                 = "tcp"
-      cidr_blocks              = []
-      source_security_group_id = module.vpc.vpc_default_security_group_id
-      description              = "Allow ingress traffic to EFS from trusted Security Groups"
-    }
-  ]
+  associated_security_group_ids   = [module.efs_security_group.id]
+  create_security_group           = false
 
   transition_to_ia = ["AFTER_7_DAYS"]
 
   security_group_create_before_destroy = false
 
   context = module.this.context
+}
+
+  module "efs_security_group" {
+  source = "cloudposse/security-group/aws"
+
+  name                       = "prod_efs_security_group"
+  security_group_name        = ["prod_efs_security_group"]
+  security_group_description = "Security Group for EFS for prod hosts"
+  vpc_id                     = module.vpc.vpc_id
+
+  rules = [
+    {
+      type                     = "ingress"
+      from_port                = 2049
+      to_port                  = 2049
+      protocol                 = "TCP"
+      source_security_group_id = module.vpc.vpc_default_security_group_id
+      description              = "Allow EC2 instances to get access on EFS over port 2049"
+    }
+  ]
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -32,34 +32,48 @@ module "efs" {
   vpc_id  = module.vpc.vpc_id
   subnets = module.subnets.private_subnet_ids
 
-  efs_backup_policy_enabled       = true
+  access_points = {
+    "data" = {
+      posix_user = {
+        gid            = "1001"
+        uid            = "5000"
+        secondary_gids = "1002,1003"
+      }
+      creation_info = {
+        gid         = "1001"
+        uid         = "5000"
+        permissions = "0755"
+      }
+    }
+    "data2" = {
+      posix_user = {
+        gid            = "2001"
+        uid            = "6000"
+        secondary_gids = null
+      }
+      creation_info = {
+        gid         = "123"
+        uid         = "222"
+        permissions = "0555"
+      }
+    }
+  }
 
-  associated_security_group_ids   = [module.efs_security_group.id]
-  create_security_group           = false
+  additional_security_group_rules = [
+    {
+      type                     = "ingress"
+      from_port                = 2049
+      to_port                  = 2049
+      protocol                 = "tcp"
+      cidr_blocks              = []
+      source_security_group_id = module.vpc.vpc_default_security_group_id
+      description              = "Allow ingress traffic to EFS from trusted Security Groups"
+    }
+  ]
 
   transition_to_ia = ["AFTER_7_DAYS"]
 
   security_group_create_before_destroy = false
 
   context = module.this.context
-}
-
-  module "efs_security_group" {
-  source = "cloudposse/security-group/aws"
-
-  name                       = "prod_efs_security_group"
-  security_group_name        = ["prod_efs_security_group"]
-  security_group_description = "Security Group for EFS for prod hosts"
-  vpc_id                     = module.vpc.vpc_id
-
-  rules = [
-    {
-      type                     = "ingress"
-      from_port                = 2049
-      to_port                  = 2049
-      protocol                 = "TCP"
-      source_security_group_id = module.vpc.vpc_default_security_group_id
-      description              = "Allow EC2 instances to get access on EFS over port 2049"
-    }
-  ]
 }

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "aws_efs_mount_target" "default" {
   ip_address     = var.mount_target_ip_address
   subnet_id      = var.subnets[count.index]
   security_groups = compact(
-    sort(concat(
+    (concat(
       [module.security_group.id],
       var.associated_security_group_ids
     ))


### PR DESCRIPTION
## what
* remove sort function in security_groups

## why
* if create_security_group is false, then the module throws exception "Call to function "sort" failed: given list element 0 is null; a null string cannot be sorted."

## references
* [Associated Security Groups doesn't work](https://github.com/cloudposse/terraform-aws-efs/issues/102)

