### PR TITLE
Migrate new test account

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -8,9 +8,10 @@ permissions:
   pull-requests: write
   id-token: write
   contents: write
+  statuses: write
 
 jobs:
-  terraform-module:
+  test:
     uses: cloudposse/.github/.github/workflows/shared-terraform-chatops.yml@main
-    secrets:
-      github_access_token: ${{ secrets.REPO_ACCESS_TOKEN }}
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/terratest') }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,10 @@ on:
     types:
       - published
 
-permissions: {}
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
 
 jobs:
   terraform-module:

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,5 +1,6 @@
 provider "aws" {
-  region = var.region
+  region      = var.region
+  description = "AWS region"
 }
 
 module "vpc" {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,6 +1,5 @@
 provider "aws" {
-  region      = var.region
-  description = "AWS region"
+  region = var.region
 }
 
 module "vpc" {

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,13 +1,16 @@
 output "public_subnet_cidrs" {
-  value = module.subnets.public_subnet_cidrs
+  value       = module.subnets.public_subnet_cidrs
+  description = "List of public subnet CIDRs"
 }
 
 output "private_subnet_cidrs" {
-  value = module.subnets.private_subnet_cidrs
+  value       = module.subnets.private_subnet_cidrs
+  description = "List of private subnet CIDRs"
 }
 
 output "vpc_cidr" {
-  value = module.vpc.vpc_cidr_block
+  value       = module.vpc.vpc_cidr_block
+  description = "VPC CIDR"
 }
 
 output "efs_arn" {

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,5 +1,6 @@
 variable "region" {
-  type = string
+  type        = string
+  description = "AWS region"
 }
 
 variable "availability_zones" {


### PR DESCRIPTION
## what
- Update `.github/settings.yml` 
- Update `.github/chatops.yml` files

## why
- Re-apply `.github/settings.yml` from org level to get `terratest` environment
- Migrate to new `test` account

## References
* DEV-388 Automate clean up of test account in new organization
* DEV-387 Update terratest to work on a shared workflow instead of a dispatch action
* DEV-386 Update terratest to use new testing account with GitHub OIDC

